### PR TITLE
Added alternative command_bus distribution

### DIFF
--- a/DependencyInjection/CommandBusConfiguration.php
+++ b/DependencyInjection/CommandBusConfiguration.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\CommandBus\DependencyInjection;
 
+use Drift\CommandBus\Bus\Bus;
 use Mmoreram\BaseBundle\DependencyInjection\BaseConfiguration;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
@@ -36,6 +37,10 @@ class CommandBusConfiguration extends BaseConfiguration
                 ->arrayNode('query_bus')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->enumNode('distribution')
+                            ->values([Bus::DISTRIBUTION_INLINE, Bus::DISTRIBUTION_NEXT_TICK])
+                            ->defaultValue(Bus::DISTRIBUTION_INLINE)
+                        ->end()
                         ->arrayNode('middlewares')
                             ->scalarPrototype()
                                 ->defaultValue([])
@@ -47,6 +52,10 @@ class CommandBusConfiguration extends BaseConfiguration
                 ->arrayNode('command_bus')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->enumNode('distribution')
+                            ->values([Bus::DISTRIBUTION_INLINE, Bus::DISTRIBUTION_NEXT_TICK])
+                            ->defaultValue(Bus::DISTRIBUTION_INLINE)
+                        ->end()
                         ->arrayNode('middlewares')
                             ->scalarPrototype()
                                 ->defaultValue([])

--- a/DependencyInjection/CommandBusExtension.php
+++ b/DependencyInjection/CommandBusExtension.php
@@ -65,7 +65,9 @@ class CommandBusExtension extends BaseExtension
     {
         return [
             'bus.query_bus.middlewares' => $config['query_bus']['middlewares'],
+            'bus.query_bus.distribution' => $config['query_bus']['distribution'],
             'bus.command_bus.middlewares' => $config['command_bus']['middlewares'],
+            'bus.command_bus.distribution' => $config['command_bus']['distribution'],
             'bus.command_bus.async_adapter' => $config['command_bus']['async_adapter'] ?? false,
         ];
     }

--- a/DependencyInjection/CompilerPass/BusCompilerPass.php
+++ b/DependencyInjection/CompilerPass/BusCompilerPass.php
@@ -28,6 +28,7 @@ use Drift\CommandBus\Exception\InvalidMiddlewareException;
 use Drift\CommandBus\Middleware\AsyncMiddleware;
 use Drift\CommandBus\Middleware\HandlerMiddleware;
 use Drift\CommandBus\Middleware\Middleware;
+use React\EventLoop\LoopInterface;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -172,11 +173,13 @@ class BusCompilerPass implements CompilerPassInterface
     {
         $container->setDefinition('drift.query_bus', (new Definition(
             QueryBus::class, [
+                new Reference(LoopInterface::class),
                 $this->createMiddlewaresArray(
                     $container,
                     'query',
                     false
                 ),
+                $container->getParameter('bus.query_bus.distribution'),
             ]
         ))
             ->addTag('preload')
@@ -198,11 +201,13 @@ class BusCompilerPass implements CompilerPassInterface
     ) {
         $container->setDefinition('drift.command_bus', (new Definition(
             CommandBus::class, [
+                new Reference(LoopInterface::class),
                 $this->createMiddlewaresArray(
                     $container,
                     'command',
                     $asyncBus
                 ),
+                $container->getParameter('bus.command_bus.distribution'),
             ]
         ))
             ->addTag('preload')
@@ -221,11 +226,13 @@ class BusCompilerPass implements CompilerPassInterface
     {
         $container->setDefinition('drift.inline_command_bus', (new Definition(
             InlineCommandBus::class, [
+                new Reference(LoopInterface::class),
                 $this->createMiddlewaresArray(
                     $container,
                     'command',
                     false
                 ),
+                $container->getParameter('bus.command_bus.distribution'),
             ]
         ))
             ->addTag('preload')

--- a/Tests/Bus/CommandHandlerTest.php
+++ b/Tests/Bus/CommandHandlerTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\CommandBus\Tests\Bus;
 
+use Drift\CommandBus\Bus\Bus;
 use Drift\CommandBus\Middleware\HandlerMiddleware;
 use Drift\CommandBus\Tests\BusFunctionalTest;
 use Drift\CommandBus\Tests\Command\ChangeAThing;
@@ -44,7 +45,21 @@ class CommandHandlerTest extends BusFunctionalTest
             ],
         ];
 
+        $configuration['command_bus']['command_bus']['distribution'] = self::distributedBus()
+            ? Bus::DISTRIBUTION_NEXT_TICK
+            : Bus::DISTRIBUTION_INLINE;
+
         return $configuration;
+    }
+
+    /**
+     * Create distributed bus.
+     *
+     * @return bool
+     */
+    protected static function distributedBus(): bool
+    {
+        return false;
     }
 
     /**

--- a/Tests/Bus/DistributedCommandHandlerTest.php
+++ b/Tests/Bus/DistributedCommandHandlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\CommandBus\Tests\Bus;
+
+/**
+ * Class DistributedCommandHandlerTest.
+ */
+class DistributedCommandHandlerTest extends CommandHandlerTest
+{
+    /**
+     * Create distributed bus.
+     *
+     * @return bool
+     */
+    protected static function distributedBus(): bool
+    {
+        return true;
+    }
+}

--- a/Tests/Bus/DistributedQueryHandlerTest.php
+++ b/Tests/Bus/DistributedQueryHandlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\CommandBus\Tests\Bus;
+
+/**
+ * Class DistributedQueryHandlerTest.
+ */
+class DistributedQueryHandlerTest extends QueryHandlerTest
+{
+    /**
+     * Create distributed bus.
+     *
+     * @return bool
+     */
+    protected static function distributedBus(): bool
+    {
+        return true;
+    }
+}

--- a/Tests/Bus/QueryHandlerTest.php
+++ b/Tests/Bus/QueryHandlerTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\CommandBus\Tests\Bus;
 
+use Drift\CommandBus\Bus\Bus;
 use Drift\CommandBus\Exception\InvalidCommandException;
 use Drift\CommandBus\Tests\BusFunctionalTest;
 use Drift\CommandBus\Tests\Context;
@@ -44,7 +45,21 @@ class QueryHandlerTest extends BusFunctionalTest
             ],
         ];
 
+        $configuration['command_bus']['query_bus']['distribution'] = self::distributedBus()
+            ? Bus::DISTRIBUTION_NEXT_TICK
+            : Bus::DISTRIBUTION_INLINE;
+
         return $configuration;
+    }
+
+    /**
+     * Create distributed bus.
+     *
+     * @return bool
+     */
+    protected static function distributedBus(): bool
+    {
+        return false;
     }
 
     /**


### PR DESCRIPTION
- Regular distribution would place all middlewares in the same tick, but
in alternative distribution, you can place each middleware call in the
next tick
- By default, regular. Can be changed in configuration